### PR TITLE
Export Confluence pages to Docusaurus

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -1,0 +1,36 @@
+name: "Export to GitHub"
+on:
+  schedule:
+    # Run at half past the hour, every hour, every weekday.
+    - cron:  '30 * * * 1-5'
+env:
+  CONFLUENCE_DOMAIN: burendo
+
+jobs:
+  export_pages:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+      working-directory: scripts
+
+    - name: Export Confluence pages
+      env:
+        CONFLUENCE_AUTH_TOKEN: ${{ secrets.CONFLUENCE_AUTH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CONFLUENCE_DOMAIN: $CONFLUENCE_DOMAIN
+        GITHUB_REPOSITORY: ${{ github.event.repository.name }}
+      run: python export.py
+      working-directory: scripts
+      

--- a/.github/workflows/relabel.yml
+++ b/.github/workflows/relabel.yml
@@ -1,0 +1,40 @@
+name: Update Confluence Labels
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+env:
+  CONFLUENCE_DOMAIN: burendo
+
+jobs:
+  update_labels:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+      working-directory: scripts
+
+    - name: Update Confluence labels
+      env:
+        CONFLUENCE_AUTH_TOKEN: ${{ secrets.CONFLUENCE_AUTH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CONFLUENCE_DOMAIN: $CONFLUENCE_DOMAIN
+        GITHUB_REPOSITORY: ${{ github.event.repository.name }}
+        INPUT_PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: python post_merge.py
+      working-directory: scripts

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -1,0 +1,50 @@
+import requests
+import os
+from datetime import datetime
+from pandoc import convert_text
+from github import Github
+
+# Step 1: Search for Confluence pages with the specific label
+domain = os.environ["CONFLUENCE_DOMAIN"]
+confluence_auth_token = os.environ["CONFLUENCE_AUTH_TOKEN"]
+confluence_api_url = f"https://{domain}.atlassian.net/wiki/rest/api/content/search"
+label = "export_to_github"
+query = f'cql=type=page and label="{label}"'
+headers = {"Authorization": f"Basic {confluence_auth_token}"}
+response = requests.get(confluence_api_url, headers=headers, params=query)
+pages = response.json()["results"]
+github_token = os.environ["GITHUB_TOKEN"]
+
+# Step 2: Iterate through the filtered list of pages
+for page in pages:
+    page_id = page["id"]
+    page_title = page["title"]
+
+    # Access Confluence content
+    content_url = f"https://{domain}.atlassian.net/wiki/rest/api/content/{page_id}?expand=space"
+    content_response = requests.get(content_url, headers=headers)
+    content_data = content_response.json()
+    confluence_content = content_data["body"]["storage"]["value"]
+    space_name = content_data["space"]["name"]
+
+    # Convert Confluence content to Markdown
+    markdown_content = convert_text(confluence_content, 'markdown', format='confluence_storage')
+
+    # Create or update Markdown files in GitHub
+    github_token = os.environ["GITHUB_TOKEN"]
+    repo_name = os.environ["GITHUB_REPOSITORY"]
+    file_path = f"docs/{space_name}/{page_title}.md"
+    commit_message = f"Updated {page_title} from Confluence"
+
+    github_instance = Github(github_token)
+    repo = github_instance.get_repo(repo_name)
+
+    base_branch = repo.get_branch("main")
+    branch_name = f"{page_title}_{datetime.now().strftime('%Y%m%d%H%M%S')}"
+    repo.create_git_ref(ref=f"refs/heads/{branch_name}", sha=base_branch.commit.sha)
+
+    try:
+        contents = repo.get_contents(file_path, ref=branch_name)
+        repo.update_file(contents.path, commit_message, markdown_content, contents.sha, branch=branch_name)
+    except Exception:
+        repo.create_file(file_path, commit_message, markdown_content, branch=branch_name)

--- a/scripts/post_merge.py
+++ b/scripts/post_merge.py
@@ -1,0 +1,44 @@
+import os
+import requests
+import re
+from datetime import datetime
+from github import Github
+
+def update_confluence_labels():
+    # Set up the GitHub and Confluence API
+    domain = os.environ["CONFLUENCE_DOMAIN"]
+    github_token = os.environ["GITHUB_TOKEN"]
+    confluence_auth_token = os.environ["CONFLUENCE_AUTH_TOKEN"]
+
+    github_instance = Github(github_token)
+    repo = github_instance.get_repo(os.environ["GITHUB_REPOSITORY"])
+    pr_number = os.environ["INPUT_PR_NUMBER"]
+    pull_request = repo.get_pull(int(pr_number))
+
+    merged_branch_name = pull_request.head.ref
+
+    # Extract Confluence page IDs from the merged branch name
+    page_ids = re.findall(r'\d+', merged_branch_name)
+
+    # Update Confluence labels
+    headers = {"Authorization": f"Basic {confluence_auth_token}"}
+    date_label = datetime.now().strftime("exported_%Y%m%d")
+
+    for page_id in page_ids:
+        # Remove the 'export_to_github' label
+        confluence_api_url = f"https://{domain}.atlassian.net/wiki/rest/api/content/{page_id}/label"
+        response = requests.get(confluence_api_url, headers=headers)
+        labels = response.json()["results"]
+
+        for label in labels:
+            if label["name"] == "export_to_github":
+                label_id = label["id"]
+                delete_url = f"https://{domain}.atlassian.net/wiki/rest/api/content/{page_id}/label"
+
+        # Add the 'exported_<date>' label
+        new_label_data = {"prefix": "global", "name": date_label}
+        add_label_url = f"https://{domain}.atlassian.net/wiki/rest/api/content/{page_id}/label"
+        requests.post(add_label_url, headers=headers, json=new_label_data)
+
+if __name__ == "__main__":
+    update_confluence_labels()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+pandoc==2.3
+PyGithub==1.58.1
+requests==2.28.2


### PR DESCRIPTION
- Create script that uses the Confluence API to find labeld pages that match a pattern, convert those pages to markdown, create an appropriately named branch and land the converted file(s).
- Create script that on merge, uses the Confluence API to relabel exported pages so they are not exported again, and to acknowledge the export in Confluence.
- Create cron triggered action, that runs the export script
- Create merge triggered action that relabels exported pages
